### PR TITLE
Include first donation in the batch

### DIFF
--- a/CRM/Civigiftaid/Utils/GiftAid.php
+++ b/CRM/Civigiftaid/Utils/GiftAid.php
@@ -591,8 +591,8 @@ class CRM_Civigiftaid_Utils_GiftAid {
       }
 
       // Convert dates to timestamps.
-      $startDateTS = strtotime($declaration['start_date']);
-      $endDateTS = !empty($declaration['end_date']) ? strtotime($declaration['end_date']) : NULL;
+      $startDateTS = strtotime(date('Ymd 00:00:00', strtotime($declaration['start_date'])));
+      $endDateTS = !empty($declaration['end_date']) ? strtotime(date('Ymd 00:00:00', strtotime($declaration['end_date']))) : NULL;
       $contributionDateTS = strtotime($contribution['receive_date']);
 
       /**


### PR DESCRIPTION
Due to the timestamp on the declaration is created after the contribution hence the first donation doesn't get included in batch. Set the timestamp as the date of the donation rather than exact time.