### PR TITLE
Fix install notices

### DIFF
--- a/CRM/Civigiftaid/Upgrader.php
+++ b/CRM/Civigiftaid/Upgrader.php
@@ -378,7 +378,7 @@ class CRM_Civigiftaid_Upgrader extends CRM_Civigiftaid_Upgrader_Base {
       $optionGroups[$groupName] = civicrm_api3('OptionGroup', 'get', [
         'name' => $groupName,
       ]);
-      if ($optionGroups[$groupName]['id']) {
+      if ($optionGroups[$groupName]['id'] ?? NULL) {
         $groupParams['id'] = $optionGroups[$groupName]['id'];
       }
       // Add new option groups and options

--- a/xml/auto_install.xml
+++ b/xml/auto_install.xml
@@ -48,6 +48,7 @@
       <note_rows>4</note_rows>
       <column_name>eligible_for_gift_aid</column_name>
       <option_group_id>1</option_group_id>
+      <option_type>0</option_type>
       <custom_group_name>Gift_Aid_Declaration</custom_group_name>
     </CustomField>
     <CustomField>
@@ -137,6 +138,7 @@
       <note_rows>4</note_rows>
       <column_name>reason_ended</column_name>
       <option_group_id>1</option_group_id>
+      <option_type>0</option_type>
       <custom_group_name>Gift_Aid_Declaration</custom_group_name>
     </CustomField>
     <CustomField>
@@ -207,6 +209,7 @@
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
       <option_group_id>1</option_group_id>
+      <option_type>0</option_type>
       <column_name>eligible_for_gift_aid</column_name>
       <custom_group_name>Gift_Aid</custom_group_name>
     </CustomField>
@@ -259,6 +262,7 @@
       <note_columns>60</note_columns>
       <note_rows>4</note_rows>
       <option_group_id>1</option_group_id>
+      <option_type>0</option_type>
       <column_name>batch_name</column_name>
       <custom_group_name>Gift_Aid</custom_group_name>
     </CustomField>


### PR DESCRIPTION
When installing I got screens and screens of errors about missing 'option_type' param.

I've provided that in the xml for the option values and also put a check in the upgrader base class (which civix made).