### PR TITLE
Fix install setting default batch when it shouldn't; add first two tests

### DIFF
--- a/CRM/Civigiftaid/Declaration.php
+++ b/CRM/Civigiftaid/Declaration.php
@@ -267,14 +267,12 @@ class CRM_Civigiftaid_Declaration {
   public static function getContactsWithDeclarations() {
     $contactsWithDeclarations = [];
     $sql = "
-        SELECT id, eligible_for_gift_aid, entity_id
-        FROM   civicrm_value_gift_aid_declaration
+        SELECT   entity_id
+        FROM     civicrm_value_gift_aid_declaration
         GROUP BY entity_id";
 
-    $dao = CRM_Core_DAO::executeQuery($sql);
-    foreach ($dao->fetchAll() as $row) {
-      $contactsWithDeclarations[] = $row['entity_id'];
-    }
+    $contactsWithDeclarations = CRM_Core_DAO::executeQuery($sql)
+      ->fetchMap('entity_id', 'entity_id');
 
     return $contactsWithDeclarations;
   }

--- a/CRM/Civigiftaid/Upgrader.php
+++ b/CRM/Civigiftaid/Upgrader.php
@@ -26,6 +26,14 @@ class CRM_Civigiftaid_Upgrader extends CRM_Civigiftaid_Upgrader_Base {
    * Example: Run an external SQL script when the module is installed
    */
   public function install() {
+    // For some reason, possibly to do with the way auto_install.xml is handled
+    // and the fact that it includes `<option_group_id>1</>`, we end up with
+    // the underlying table having a default batch value of '1' - it should be
+    // NULL. Note that this query (or similar) is included in an old upgrade
+    // (sql/upgrade_20.sql), so it's likely that only sites installing this new
+    // suffer.
+    $this->executeSqlFile('sql/reset_batch_name_default.sql');
+
     $this->setOptionGroups();
     $this->enableOptionGroups(1);
     $this->setCustomFields();
@@ -34,7 +42,6 @@ class CRM_Civigiftaid_Upgrader extends CRM_Civigiftaid_Upgrader_Base {
     $this->upgrade_3103();
     $this->upgrade_3104();
   }
-
   /**
    * Example: Run an external SQL script when the module is uninstalled
    */
@@ -155,6 +162,21 @@ class CRM_Civigiftaid_Upgrader extends CRM_Civigiftaid_Upgrader_Base {
   public function upgrade_3107() {
     $this->log('Updating custom fields');
     $this->setCustomFields();
+    return TRUE;
+  }
+
+  /**
+   * There's the chance of ambiguity on the default value of batch_name,
+   * which should be NULL. This was causing tests to fail on new installs
+   * and historically a lot has changed around this so better to make sure
+   * the default is applied here too.
+   *
+   * @see https://github.com/mattwire/uk.co.compucorp.civicrm.giftaid/pull/18
+   * @see comment in install()
+   */
+  public function upgrade_3108() {
+    $this->log('Updating default batch_name');
+    $this->executeSqlFile('sql/reset_batch_name_default.sql');
     return TRUE;
   }
 

--- a/api/v3/GiftAid.php
+++ b/api/v3/GiftAid.php
@@ -35,24 +35,28 @@ function _civicrm_api3_gift_aid_updateeligiblecontributions_spec(&$params) {
  * @throws \CiviCRM_API3_Exception
  */
 function civicrm_api3_gift_aid_updateeligiblecontributions($params) {
+
+  $customBatchName = CRM_Civigiftaid_Utils::getCustomByName('batch_name', 'Gift_Aid');
+  $customEligible = CRM_Civigiftaid_Utils::getCustomByName('Eligible_for_Gift_Aid', 'Gift_Aid');
+
   $contributionParams = [
     'return' => [
       'id',
       'contact_id',
       'contribution_status_id',
       'receive_date',
-      CRM_Civigiftaid_Utils::getCustomByName('batch_name', 'Gift_Aid'),
-      CRM_Civigiftaid_Utils::getCustomByName('Eligible_for_Gift_Aid', 'Gift_Aid')
+      $customBatchName,
+      $customEligible,
     ],
     'options' => ['limit' => $params['limit'] ?? 0],
   ];
   if (empty($params['recalculate_amount'])) {
     // Only retrieve contributions that do not have eligibility set
-    $contributionParams[CRM_Civigiftaid_Utils::getCustomByName('Eligible_for_Gift_Aid', 'Gift_Aid')] = ['IS NULL' => 1];
+    $contributionParams[$customEligible] = ['IS NULL' => 1];
   }
   else {
     // Retrieve all contributions that are eligible for gift aid
-    $contributionParams[CRM_Civigiftaid_Utils::getCustomByName('Eligible_for_Gift_Aid', 'Gift_Aid')] = 1;
+    $contributionParams[$customEligible] = 1;
   }
   if (!empty($params['contribution_id'])) {
     $contributionParams['id'] = $params['contribution_id'];
@@ -64,7 +68,7 @@ function civicrm_api3_gift_aid_updateeligiblecontributions($params) {
 
   foreach ($contributions as $contributionID => $contributionDetail) {
     // Check batch name here because it may be NULL or empty string and we can't check that using API3.
-    if (!empty($contributionDetail[CRM_Civigiftaid_Utils::getCustomByName('batch_name', 'Gift_Aid')])) {
+    if (!empty($contributionDetail[$customBatchName])) {
       // Contribution is part of a batch so we must not change/process it.
       continue;
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+  <testsuites>
+    <testsuite name="My Test Suite">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">./</directory>
+    </whitelist>
+  </filter>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+</phpunit>

--- a/sql/reset_batch_name_default.sql
+++ b/sql/reset_batch_name_default.sql
@@ -1,0 +1,1 @@
+ALTER TABLE civicrm_value_gift_aid_submission MODIFY `batch_name` VARCHAR(255) NULL DEFAULT NULL;

--- a/tests/phpunit/CRM/Civigiftaid/Utils/ContributionTest.php
+++ b/tests/phpunit/CRM/Civigiftaid/Utils/ContributionTest.php
@@ -1,0 +1,191 @@
+<?php
+
+use CRM_Civigiftaid_ExtensionUtil as E;
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * Tests for CRM/Civigiftaid/Utils/Contribution.php class
+ *
+ * Tips:
+ *  - With HookInterface, you may implement CiviCRM hooks directly in the test class.
+ *    Simply create corresponding functions (e.g. "hook_civicrm_post(...)" or similar).
+ *  - With TransactionalInterface, any data changes made by setUp() or test****() functions will
+ *    rollback automatically -- as long as you don't manipulate schema or truncate tables.
+ *    If this test needs to manipulate schema or truncate tables, then either:
+ *       a. Do all that using setupHeadless() and Civi\Test.
+ *       b. Disable TransactionalInterface, and handle all setup/teardown yourself.
+ *
+ * @group headless
+ */
+class CRM_Civigiftaid_Utils_ContributionTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+
+
+  /** @var array */
+  protected $contacts = [];
+  /** @var array */
+  protected $contributions = [];
+  /** @var array */
+  protected $declarations = [];
+
+  public function setUpHeadless() {
+    // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+    // See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  public function setUp() {
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   */
+  public function testValidateContribToBatch() {
+    $this->setupFixture1();
+
+    $contributionGiftAidField = CRM_Civigiftaid_Utils::getCustomByName('Eligible_For_Gift_Aid', 'Gift_Aid');
+    $contactGiftAidField = CRM_Civigiftaid_Utils::getCustomByName('Eligible_For_Gift_Aid', 'Gift_Aid_Declaration');
+
+    // Create contribution
+    // This doesn't work with api4 so we use api3
+    $contributionID = civicrm_api3('Contribution', 'create', [
+      'contact_id' => $this->contacts[0]['id'],
+      'financial_type_id' => 1,
+      'total_amount' => 100,
+      $contributionGiftAidField => 1,
+    ])['id'];
+    $this->assertGreaterThan(0, $contributionID);
+
+    // Re-fetch the contribution details.
+    $contributions = \Civi\Api4\Contribution::get()
+      ->setCheckPermissions(FALSE)
+      ->addSelect('Gift_Aid.Eligible_for_Gift_Aid', 'Gift_Aid.Amount', 'Gift_Aid.Gift_Aid_Amount', 'Gift_Aid.Batch_Name')
+      ->addWhere('id', '=', $contributionID)
+      ->execute()[0];
+
+    //$this->dump();
+    $this->assertEquals(1, $contributions['Gift_Aid.Eligible_for_Gift_Aid'] ?? NULL);
+    $this->assertEquals(100, $contributions['Gift_Aid.Amount'] ?? NULL);
+    $this->assertEquals(25, $contributions['Gift_Aid.Gift_Aid_Amount'] ?? NULL);
+    $this->assertEquals('', $contributions['Gift_Aid.Batch_Name'] ?? NULL);
+
+    //$this->assertNull($contributions['Gift_Aid.Amount'] ?? NULL);
+    //$this->assertEquals(NULL, $contributions['Gift_Aid.Gift_Aid_Amount'] ?? NULL);
+    //$this->assertEquals(NULL, $contributions['Gift_Aid.Gift_Batch_Name'] ?? NULL);
+
+    // CRM_Civigiftaid_Utils::getCustomByName('batch_name', 'Gift_Aid'),
+    // CRM_Civigiftaid_Utils::getCustomByName('Eligible_for_Gift_Aid', 'Gift_Aid'),
+  }
+
+  /**
+   * When creating a contribution with API4 for some reason it
+   * does not seem to save the custom fields.
+   * Not sure if this is to do with this extension or api4
+   */
+  public function testCreateContribWithApi4SetsCustomData() {
+    $this->setupFixture1();
+
+    // Create contribution
+    $contributionID = \Civi\Api4\Contribution::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('contact_id', $this->contacts[0]['id'])
+      ->addValue('financial_type_id', 1)
+      ->addValue('total_amount', 100)
+      ->addValue('Gift_Aid.Eligible_for_Gift_Aid', 1)
+      ->execute()[0]['id'] ?? 0;
+    $this->assertGreaterThan(0, $contributionID);
+
+    // Re-fetch the contribution details.
+    $contributions = \Civi\Api4\Contribution::get()
+      ->setCheckPermissions(FALSE)
+      ->addSelect('Gift_Aid.Eligible_for_Gift_Aid', 'Gift_Aid.Amount', 'Gift_Aid.Gift_Aid_Amount', 'Gift_Aid.Batch_Name')
+      ->addWhere('id', '=', $contributionID)
+      ->execute()[0];
+
+    $this->assertEquals(1, $contributions['Gift_Aid.Eligible_for_Gift_Aid'] ?? NULL);
+    $this->assertEquals(100, $contributions['Gift_Aid.Amount'] ?? NULL);
+    $this->assertEquals(25, $contributions['Gift_Aid.Gift_Aid_Amount'] ?? NULL);
+    $this->assertEquals('', $contributions['Gift_Aid.Batch_Name'] ?? NULL);
+  }
+
+  protected function dump() {
+
+    $customFieldID = CRM_Core_BAO_CustomField::getCustomFieldID('Eligible_for_Gift_Aid', 'Gift_Aid');
+    $customContribTableName = CRM_Core_BAO_CustomField::getTableColumnGroup($customFieldID)[0];
+
+    $dao = CRM_Core_DAO::executeQuery("SELECT id, contact_type, display_name FROM civicrm_contact ORDER BY id");
+    echo "\nContacts:\n";
+    while ($dao->fetch()) {
+      print "  $dao->id: $dao->contact_type $dao->display_name\n";
+    }
+    print "\n";
+    $sql = "
+      SELECT c.id, c.contact_id, c.receive_date, c.total_amount,
+          ga.id ga_id, ga.eligible_for_gift_aid, ga.amount ga_amount, ga.gift_aid_amount, ga.batch_name
+      FROM civicrm_contribution c
+      LEFT JOIN $customContribTableName ga ON ga.entity_id = c.id
+      ORDER BY c.id";
+    $dao = CRM_Core_DAO::executeQuery($sql);
+    echo "\nContributions:\n";
+    while ($dao->fetch()) {
+      $_ = $dao->toArray();
+      foreach ($_ as $k => $v) {
+        print "  $k: " . json_encode($v) ."\n";
+      }
+      print "\n";
+    }
+    print "\n";
+
+
+    $sql = "
+      SELECT *
+      FROM $customContribTableName
+      ORDER BY id";
+    $dao = CRM_Core_DAO::executeQuery($sql);
+    echo "\n$customContribTableName :\n";
+    while ($dao->fetch()) {
+      $_ = $dao->toArray();
+      foreach ($_ as $k => $v) {
+        print "  $k: " . json_encode($v) ."\n";
+      }
+      print "\n";
+    }
+    print "\n";
+
+  }
+  /**
+   */
+  protected function setupFixture1() {
+
+    // Create a contact.
+    $result = \Civi\Api4\Contact::create()
+      ->setCheckPermissions(FALSE)
+      ->addValue('contact_type', 'Individual')
+      ->addValue('display_name', 'Test 123')
+      ->execute()[0];
+    $this->contacts[] = $result;
+    $contactID = $this->contacts[0]['id'];
+
+    // Create a declaration for this contact.
+    // Nb. as of CiviCRM 5.25 this API doesn't return anything useful like the ID of the created declaration.
+    \Civi\Api4\CustomValue::create('Gift_Aid_Declaration')
+      ->addValue('entity_id', $contactID)
+      ->addValue('Eligible_for_Gift_Aid', 1)
+      ->addValue('Address', 'somewhere')
+      ->addValue('Post_Code', 'SW1A 0AA')
+      ->addValue('Start_Date', '2020-01-01')
+      ->addValue('Source', 'test 1')
+      ->execute();
+
+    // Set globally enabled.
+    Civi::settings()->set('civigiftaid_globally_enabled', 1);
+  }
+
+}

--- a/tests/phpunit/CRM/Civigiftaid/Utils/ContributionTest.php
+++ b/tests/phpunit/CRM/Civigiftaid/Utils/ContributionTest.php
@@ -34,9 +34,13 @@ class CRM_Civigiftaid_Utils_ContributionTest extends \PHPUnit\Framework\TestCase
   public function setUpHeadless() {
     // Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
     // See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+
+    // Set to TRUE to force a reset - but your tests will take forever.
+    $forceResetDatabase = FALSE;
+
     return \Civi\Test::headless()
       ->installMe(__DIR__)
-      ->apply();
+      ->apply($forceResetDatabase);
   }
 
   public function setUp() {

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,63 @@
+<?php
+
+ini_set('memory_limit', '2G');
+ini_set('safe_mode', 0);
+// phpcs:ignore
+eval(cv('php:boot --level=classloader', 'phpcode'));
+
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', __DIR__);
+$loader->add('Civi\\', __DIR__);
+$loader->add('api_', __DIR__);
+$loader->add('api\\', __DIR__);
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return string
+ *   Response output (if the command executed normally).
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv($cmd, $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}


### PR DESCRIPTION
I've started adding some phpunit tests. They're throwing up some interesting issues.

First, in order that the code is testable with headless tests, we cannot use `CRM_Core_Transaction::addCallback(CRM_Core_Transaction::PHASE_POST_COMMIT, ...)` because the headless tests encapsulate everything in a transaction, so that hook never fires.

I reworked the code for that hook using a Symfony event that fires for api responses.

The purpose of the code I changed was to set the giftaid fields when a contribution is edited/created. So far I'm looking at creation.

I have found discrepancies in behaviour based on whether api3 or api4 is used.

- API3 seems to think that 'batch name' has a default value of `'1'`, and sets it so. 
- The SQL table `civicrm_value_gift_aid_submission` is also defined as having a default `batch_name` of 1
- The auto_install.xml file does not set a default value for `batch_name`, however it does set an `option_group_id` to `1` which I don't understand; batch name is not an option group is it? I'm not familiar with using autoinstall.xml (and couldn't find much documentation) so that may mean something else. But `<option_group_id>1</option_group_id>` is set on four fields: `batch_name`, `eligible_for_gift_aid` (×2 groups) and `reason_ended`.
- API4 does not pick up the default value for barch name.

To my reading of the code and docs, batch name should be NULL or `''` until contributions are assigned to a batch via the search task. In which case - why is there a default? Or is that option group declaration forcing a default that should not be there? Or does this only affect CiviCRM v 5.26 which I'm testing on?

Any pointers appreciated.